### PR TITLE
Support other filesystems, support other distros, removed bc as a dependency, multiple DNS IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,10 @@ This script is designed for us, for our internal use.
 # Dependencies
 
 - `lscpu`
-- `bc` (For math in bash)
 
 If your system is different, things might break. Look up the offending line and you can try to fix it for your specific system.
 
 # Installation
-
-Install `bc`: `apt install bc`.
 
 For login sessions over ssh, reference the script `~/.machine_report.sh` in your `.bashrc` file. Make sure the script is executable by running `chmod +x ~/.machine_report.sh`.
 
@@ -67,6 +64,16 @@ Copy `machine_report.sh` from this repository and add it to `~/.machine_report.s
 
 # Machine Report     <---------- Add this line at the end of it
 ~/.machine_report.sh
+```
+
+**DISCLAIMER**  
+This line should be somewhere above all other code in your `bashrc` file, to ensure
+that scripts don't run when you use programs such as rsync, scp, sftp and others
+that use a remote shell.
+
+```bash
+# If not running interactively, don't do anything
+[[ $- != *i* ]] && return
 ```
 
 # License

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -160,6 +160,10 @@ if [[ "$last_login_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     last_login_time=$(echo "$last_login" | awk 'NR==2 {print $6, $7, $10, $8}')
 else
     last_login_time=$(echo "$last_login" | awk 'NR==2 {print $4, $5, $8, $6}')
+    # Check for **Never logged in** edge case
+    if [ "$last_login_time" = "in**" ]; then
+        last_login_time="Never logged in"
+    fi
 fi
 
 sys_uptime=$(uptime -p | sed 's/up\s*//; s/\s*day\(s*\)/d/; s/\s*hour\(s*\)/h/; s/\s*minute\(s*\)/m/')

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -2,11 +2,6 @@
 # TR-100 Machine Report
 # Copyright © 2024, U.S. Graphics, LLC. BSD-3-Clause License.
 
-# If not running interactively, don't do anything
-# This prevents rsync/scp/sftp from breaking when this script
-# is sourced.
-[[ $- != *i* ]] && return
-
 # Basic configuration, change as needed
 report_title="UNITED STATES GRAPHICS COMPANY"
 last_login_ip_present=0

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -2,6 +2,11 @@
 # TR-100 Machine Report
 # Copyright © 2024, U.S. Graphics, LLC. BSD-3-Clause License.
 
+# If not running interactively, don't do anything
+# This prevents rsync/scp/sftp from breaking when this script
+# is sourced.
+[[ $- != *i* ]] && return
+
 # Basic configuration, change as needed
 report_title="UNITED STATES GRAPHICS COMPANY"
 last_login_ip_present=0

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -157,11 +157,9 @@ last_login_ip=$(echo "$last_login" | awk 'NR==2 {print $3}')
 # Check if last_login_ip is an IP address
 if [[ "$last_login_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     last_login_ip_present=1
-    last_login_time=$(echo "$last_login" | awk 'NR==2 {print $5, $6, $7, $8, $9}')
-    last_login_formatted_time=$(date -d "$last_login_time" "+%b %-d %Y %T")
+    last_login_time=$(echo "$last_login" | awk 'NR==2 {print $6, $7, $10, $8}')
 else
-    last_login_time=$(echo "$last_login" | awk 'NR==2 {print $3, $4, $5, $6, $7}')
-    last_login_formatted_time=$(date -d "$last_login_time" "+%b %-d %Y %T")
+    last_login_time=$(echo "$last_login" | awk 'NR==2 {print $4, $5, $8, $6}')
 fi
 
 sys_uptime=$(uptime -p | sed 's/up\s*//; s/\s*day\(s*\)/d/; s/\s*hour\(s*\)/h/; s/\s*minute\(s*\)/m/')
@@ -209,7 +207,7 @@ printf "├────────────┼──────────
 printf "│ %-10s │ %-29s │\n" "MEMORY" "${mem_used_gb}/${mem_total_gb} GiB [${mem_percent}%]"
 printf "│ %-10s │ %-29s │\n" "USAGE" "${mem_bar_graph}"
 printf "├────────────┼───────────────────────────────┤\n"
-printf "│ %-10s │ %-29s │\n" "LAST LOGIN" "$last_login_formatted_time"
+printf "│ %-10s │ %-29s │\n" "LAST LOGIN" "$last_login_time"
 
 if [ $last_login_ip_present -eq 1 ]; then
     printf "│ %-10s │ %-29s │\n" "" "$last_login_ip"

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -154,11 +154,12 @@ last_login_ip=$(echo "$last_login" | awk 'NR==2 {print $3}')
 if [[ "$last_login_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     last_login_ip_present=1
     last_login_time=$(echo "$last_login" | awk 'NR==2 {print $5, $6, $7, $8, $9}')
+    last_login_formatted_time=$(date -d "$last_login_time" "+%b %-d %Y %T")
 else
     last_login_time=$(echo "$last_login" | awk 'NR==2 {print $3, $4, $5, $6, $7}')
+    last_login_formatted_time=$(date -d "$last_login_time" "+%b %-d %Y %T")
 fi
 
-last_login_formatted_time=$(date -d "$last_login_time" "+%b %-d %Y %T")
 sys_uptime=$(uptime -p | sed 's/up\s*//; s/\s*day\(s*\)/d/; s/\s*hour\(s*\)/h/; s/\s*minute\(s*\)/m/')
 
 # Machine Report

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -92,6 +92,9 @@ if [ -z "$net_hostname" ]; then net_hostname="Not Defined"; fi
 
 net_machine_ip=$(get_ip_addr)
 net_client_ip=$(who am i | awk '{print $5}' | tr -d '()')
+if [ -z "$net_client_ip" ]; then
+    net_client_ip="Not connected"
+fi
 net_dns_ip=($(grep '^nameserver [0-9.]' /etc/resolv.conf | awk '{print $2}'))
 
 # CPU Information

--- a/machine_report.sh
+++ b/machine_report.sh
@@ -15,12 +15,18 @@ bar_graph() {
     local used=$1
     local total=$2
 
-    percent=$(printf "%.2f" "$(echo "$used / $total * 100" | bc -l)")
-    num_blocks=$(echo "scale=2; ${percent}/100*${width}" | bc -l | numfmt --from=iec --format %.0f)
+    if (( total == 0 )); then
+        percent=0
+    else
+        percent=$(awk -v used="$used" -v total="$total" 'BEGIN { printf "%.2f", (used / total) * 100 }')
+    fi
+
+    num_blocks=$(awk -v percent="$percent" -v width="$width" 'BEGIN { printf "%d", (percent / 100) * width }')
+
     for (( i = 0; i < num_blocks; i++ )); do
         graph+="█"
     done
-    for (( i=0; i < width - num_blocks; i++ )); do
+    for (( i = num_blocks; i < width; i++ )); do
         graph+="░"
     done
     printf "%s" "${graph}"
@@ -58,7 +64,7 @@ cpu_15min_bar_graph=$(bar_graph "$load_avg_15min" "$cpu_cores")
 mem_total=$(grep 'MemTotal' /proc/meminfo | awk '{print $2}')
 mem_available=$(grep 'MemAvailable' /proc/meminfo | awk '{print $2}')
 mem_used=$((mem_total - mem_available))
-mem_percent=$(echo "$mem_used / $mem_total * 100" | bc -l)
+mem_percent=$(awk -v used="$mem_used" -v total="$mem_total" 'BEGIN { printf "%.2f", (used / total) * 100 }')
 mem_percent=$(printf "%.2f" "$mem_percent")
 mem_total_gb=$(echo "$mem_total" | numfmt --from-unit=Ki --to-unit=Gi --format %.2f)
 mem_available_gb=$(echo "$mem_available" | numfmt --from-unit=Ki --to-unit=Gi --format %.2f) # Not used currently


### PR DESCRIPTION
I removed a bunch of debian only code (e.g. `hostname -I` and `who am i --ips`) so it should work on (mostly) all linux distros now, maybe Mac too but I can't test that myself.

Another big thing is that I removed the `bc` dependency because if we're using awk everywhere anyway, we can do calculations with it too instead of having to rely on `bc`.

Next I added support for other filesystems like ext4 and xfs with a bit of help from [@Anarch's fork](https://github.com/AnarchistHoneybun/TR-100).

That big `get_ip_addr` function was made so that I can remove the debian only `hostname -I` call. It's pretty nice since it's more portable now and it ignores docker and lo interfaces and only returns one ip address. It prefers IPv4, but if it can't find it it returns IPv6. At first it tries to use `ifconfig` to be backwards compatible, if the command doesn't exist it uses `ip addr`.

The `net_dns_ip` was modified to return an array because I have multiple nameservers. The old implementation also returned stuff from the comments that were autogenerated from NetworkManager so I made it more robust.

The `cpu_hypervisor` var gets checked if it actually contains a hypervisor vendor and if nothing is in the variable it will say "Bare Metal".

And lastly I un-hardcoded `last_login` var containing info for only the root user, it now takes the `$USER` env var.