### PR TITLE
add check to use PRETTY_NAME if the os_name is too long

### DIFF
--- a/machine_report.sh
+++ b/machine_report.sh
@@ -234,6 +234,9 @@ get_ip_addr() {
 # Operating System Information
 source /etc/os-release
 os_name="${ID^} ${VERSION} ${VERSION_CODENAME^}"
+if [ "${#os_name}" -gt "$MAX_NAME_LEN" ]; then 
+	os_name="${PRETTY_NAME^}"
+fi
 os_kernel=$({ uname; uname -r; } | tr '\n' ' ')
 
 # Network Information


### PR DESCRIPTION
On some systems, for example [Ubuntu](https://github.com/chef/os_release/blob/main/ubuntu_2204), the os_name string may become unreasonably long, breaking the program's formatting. This PR makes the program default to the PRETTY_NAME field. 